### PR TITLE
Add data tile to show transactions count & steps used

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ next-env.d.ts
 # wrangler files
 .wrangler
 .dev.vars
+.env

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@radix-ui/react-icons": "^1.3.0",
         "@radix-ui/react-slot": "^1.0.2",
+        "@upstash/redis": "^1.31.3",
         "camelcase-keys": "^9.1.3",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.1",
@@ -1616,6 +1617,14 @@
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
       "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
       "dev": true
+    },
+    "node_modules/@upstash/redis": {
+      "version": "1.31.3",
+      "resolved": "https://registry.npmjs.org/@upstash/redis/-/redis-1.31.3.tgz",
+      "integrity": "sha512-KtVgWBUEx/LGbR8oRwYexwzHh3s5DNqYW0bjkD+gjFZVOnREJITvK+hC4PjSSD+8D4qJ+Xbkfmy8ANADZ9EUFg==",
+      "dependencies": {
+        "crypto-js": "^4.2.0"
+      }
     },
     "node_modules/@vercel/build-utils": {
       "version": "8.2.0",
@@ -3608,6 +3617,11 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/crypto-js": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
+      "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q=="
     },
     "node_modules/cssesc": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "@radix-ui/react-icons": "^1.3.0",
     "@radix-ui/react-slot": "^1.0.2",
+    "@upstash/redis": "^1.31.3",
     "camelcase-keys": "^9.1.3",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",

--- a/src/app/api/common-stats/route.ts
+++ b/src/app/api/common-stats/route.ts
@@ -1,0 +1,8 @@
+import { fetchCommonStats } from '@/lib/api'
+
+export const runtime = 'edge'
+
+export async function GET() {
+  const commonStats = await fetchCommonStats()
+  return Response.json(commonStats)
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,23 +1,9 @@
 export const runtime = 'edge'
 
 import HomePage from '@/components/home-page'
-import { CommonStats } from '@/lib/types'
-import camelcaseKeys from 'camelcase-keys'
-
-async function getCommonStats() {
-  const res = await fetch(
-    'http://starkf-servi-1yasdoedwfh1-321738969.us-east-1.elb.amazonaws.com/rpc/get_common_data',
-    {
-      cache: 'no-store',
-    },
-  )
-  const commonStats: CommonStats = camelcaseKeys((await res.json()) as any, {
-    deep: true,
-  })
-  return commonStats
-}
+import { fetchCommonStats } from '@/lib/api'
 
 export default async function Page() {
-  const commonStats = await getCommonStats()
+  const commonStats = await fetchCommonStats()
   return <HomePage commonStats={commonStats} />
 }

--- a/src/components/home-page.tsx
+++ b/src/components/home-page.tsx
@@ -40,7 +40,10 @@ export default function HomePage({
                 optimise.
               </h2>
             </div>
-            <TxStepsStats className="col-span-4" />
+            <TxStepsStats
+              className="col-span-4"
+              transactionStats={commonStats.transactionStats}
+            />
             <FailedTxs className="col-span-3 row-span-2" />
             <GasSpentStats className="col-span-4" />
             <TotalUsersStats className="col-span-2" commonStats={commonStats} />

--- a/src/components/stats/tx-steps.tsx
+++ b/src/components/stats/tx-steps.tsx
@@ -43,13 +43,13 @@ export function TxStepsStats({
             <div className="text-2xl font-bold" style={{ color: '#8884d8' }}>
               {formatter.format(transactionsCount)}
             </div>
-            <p className="text-xs text-muted-foreground">Transactions Count</p>
+            <p className="text-xs text-muted-foreground">Transactions count</p>
           </div>
           <div>
             <div className="text-2xl font-bold" style={{ color: '#82ca9d' }}>
               {formatter.format(stepsNumber)}
             </div>
-            <p className="text-xs text-muted-foreground">Steps Number</p>
+            <p className="text-xs text-muted-foreground">Steps used</p>
           </div>
         </div>
         <div className="h-[80px]">

--- a/src/components/stats/tx-steps.tsx
+++ b/src/components/stats/tx-steps.tsx
@@ -2,7 +2,7 @@
 
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { TransactionStats } from '@/lib/types'
-import { XAxis, Line, Legend, LineChart, ResponsiveContainer } from 'recharts'
+import { XAxis, Tooltip, Line, LineChart, ResponsiveContainer } from 'recharts'
 
 export function TxStepsStats({
   className,
@@ -43,13 +43,13 @@ export function TxStepsStats({
             <div className="text-2xl font-bold" style={{ color: '#8884d8' }}>
               {formatter.format(transactionsCount)}
             </div>
-            <p className="text-xs text-muted-foreground">Transactions count</p>
+            <p className="text-xs text-muted-foreground">Transactions Count</p>
           </div>
           <div>
             <div className="text-2xl font-bold" style={{ color: '#82ca9d' }}>
               {formatter.format(stepsNumber)}
             </div>
-            <p className="text-xs text-muted-foreground">Steps used</p>
+            <p className="text-xs text-muted-foreground">Steps Used</p>
           </div>
         </div>
         <div className="h-[80px]">
@@ -64,34 +64,36 @@ export function TxStepsStats({
               }}
             >
               <XAxis dataKey="name" />
-              {/*<Legend />*/}
+              <Tooltip
+                formatter={(
+                  value: number,
+                  name: 'transactionsCount' | 'stepsNumber',
+                  props,
+                ) => {
+                  const valuesFormatted = {
+                    transactionsCount: formatter.format(value),
+                    stepsNumber: formatter.format(value * 100000),
+                  }
+                  const namesFormatted = {
+                    transactionsCount: 'Transactions Count',
+                    stepsNumber: 'Steps Used',
+                  }
+                  return [valuesFormatted[name], namesFormatted[name]]
+                }}
+              />
               <Line
                 type="monotone"
                 strokeWidth={2}
                 dataKey="transactionsCount"
-                activeDot={{
-                  r: 6,
-                  style: { fill: '#8884d8', opacity: 0.25 },
-                }}
-                style={
-                  {
-                    stroke: '#8884d8',
-                  } as React.CSSProperties
-                }
+                activeDot={{ r: 6 }}
+                stroke="#8884d8"
               />
               <Line
                 type="monotone"
                 strokeWidth={2}
                 dataKey="stepsNumber"
-                activeDot={{
-                  r: 6,
-                  style: { fill: '#82ca9d', opacity: 0.25 },
-                }}
-                style={
-                  {
-                    stroke: '#82ca9d',
-                  } as React.CSSProperties
-                }
+                activeDot={{ r: 6 }}
+                stroke="#82ca9d"
               />
             </LineChart>
           </ResponsiveContainer>

--- a/src/components/stats/tx-steps.tsx
+++ b/src/components/stats/tx-steps.tsx
@@ -1,54 +1,57 @@
 'use client'
 
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
-import { Bar, BarChart, Line, LineChart, ResponsiveContainer } from 'recharts'
+import { TransactionStats } from '@/lib/types'
+import { XAxis, Line, Legend, LineChart, ResponsiveContainer } from 'recharts'
 
-const data = [
-  {
-    revenue: 10400,
-    subscription: 10240,
-  },
-  {
-    revenue: 14405,
-    subscription: 10300,
-  },
-  {
-    revenue: 9400,
-    subscription: 8200,
-  },
-  {
-    revenue: 8200,
-    subscription: 7278,
-  },
-  {
-    revenue: 7000,
-    subscription: 10189,
-  },
-  {
-    revenue: 9600,
-    subscription: 10239,
-  },
-  {
-    revenue: 11244,
-    subscription: 10278,
-  },
-  {
-    revenue: 16475,
-    subscription: 7189,
-  },
-]
-
-export function TxStepsStats({ className }: { className?: string }) {
+export function TxStepsStats({
+  className,
+  transactionStats,
+}: {
+  className?: string
+  transactionStats: TransactionStats
+}) {
+  const data = Array.from({ length: 7 }, (_, i) => i).map((i) => {
+    const date = new Date(
+      new Date().setDate(new Date().getDate() - (6 - i) - 1),
+    )
+    return {
+      name: `${date.getDate()}/${date.getMonth() + 1}`,
+      transactionsCount: transactionStats.transactionsCountLast7Days[i],
+      stepsNumber: transactionStats.stepsNumberLast7Days[i] / 100000,
+    }
+  })
+  const transactionsCount = transactionStats.transactionsCountLast7Days.reduce(
+    (previousValue, currentValue) => previousValue + currentValue,
+    0,
+  )
+  const stepsNumber = transactionStats.stepsNumberLast7Days.reduce(
+    (previousValue, currentValue) => previousValue + currentValue,
+    0,
+  )
+  const formatter = Intl.NumberFormat('en', { notation: 'compact' })
   return (
     <Card className={className}>
       <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
         <CardTitle className="text-sm font-normal">
-          Transactions Count & Steps Used Placeholder
+          Transactions Count & Steps Used
         </CardTitle>
       </CardHeader>
       <CardContent>
-        <div className="text-2xl font-bold">$15,231.89</div>
-        <p className="text-xs text-muted-foreground">+20.1% from last month</p>
+        <div className="flex justify-between">
+          <div>
+            <div className="text-2xl font-bold" style={{ color: '#8884d8' }}>
+              {formatter.format(transactionsCount)}
+            </div>
+            <p className="text-xs text-muted-foreground">Transactions Count</p>
+          </div>
+          <div>
+            <div className="text-2xl font-bold" style={{ color: '#82ca9d' }}>
+              {formatter.format(stepsNumber)}
+            </div>
+            <p className="text-xs text-muted-foreground">Steps Number</p>
+          </div>
+        </div>
         <div className="h-[80px]">
           <ResponsiveContainer width="100%" height="100%">
             <LineChart
@@ -60,31 +63,33 @@ export function TxStepsStats({ className }: { className?: string }) {
                 bottom: 0,
               }}
             >
+              <XAxis dataKey="name" />
+              {/*<Legend />*/}
               <Line
                 type="monotone"
                 strokeWidth={2}
-                dataKey="revenue"
+                dataKey="transactionsCount"
                 activeDot={{
                   r: 6,
-                  style: { fill: 'hsl(var(--primary))', opacity: 0.25 },
+                  style: { fill: '#8884d8', opacity: 0.25 },
                 }}
                 style={
                   {
-                    stroke: 'hsl(var(--primary))',
+                    stroke: '#8884d8',
                   } as React.CSSProperties
                 }
               />
               <Line
                 type="monotone"
                 strokeWidth={2}
-                dataKey="subscription"
+                dataKey="stepsNumber"
                 activeDot={{
                   r: 6,
-                  style: { fill: 'hsl(var(--primary))', opacity: 0.25 },
+                  style: { fill: '#82ca9d', opacity: 0.25 },
                 }}
                 style={
                   {
-                    stroke: 'hsl(var(--primary))',
+                    stroke: '#82ca9d',
                   } as React.CSSProperties
                 }
               />

--- a/src/components/stats/tx-steps.tsx
+++ b/src/components/stats/tx-steps.tsx
@@ -11,6 +11,16 @@ export function TxStepsStats({
   className?: string
   transactionStats: TransactionStats
 }) {
+  const transactionsCountMin = Math.min(
+    ...transactionStats.transactionsCountLast7Days,
+  )
+  const transactionsCountMax = Math.max(
+    ...transactionStats.transactionsCountLast7Days,
+  )
+  const transactionsCountRange = transactionsCountMax - transactionsCountMin
+  const stepsNumberMin = Math.min(...transactionStats.stepsNumberLast7Days)
+  const stepsNumberMax = Math.max(...transactionStats.stepsNumberLast7Days)
+  const stepsNumberRange = stepsNumberMax - stepsNumberMin
   const data = Array.from({ length: 7 }, (_, i) => i).map((i) => {
     const date = new Date(
       new Date().setDate(new Date().getDate() - (6 - i) - 1),
@@ -18,7 +28,14 @@ export function TxStepsStats({
     return {
       name: `${date.getDate()}/${date.getMonth() + 1}`,
       transactionsCount: transactionStats.transactionsCountLast7Days[i],
-      stepsNumber: transactionStats.stepsNumberLast7Days[i] / 100000,
+      transactionsCountNormalized:
+        (transactionStats.transactionsCountLast7Days[i] -
+          transactionsCountMin) /
+        transactionsCountRange,
+      stepsNumber: transactionStats.stepsNumberLast7Days[i],
+      stepsNumberNormalized:
+        (transactionStats.stepsNumberLast7Days[i] - stepsNumberMin) /
+        stepsNumberRange,
     }
   })
   const transactionsCount = transactionStats.transactionsCountLast7Days.reduce(
@@ -67,16 +84,20 @@ export function TxStepsStats({
               <Tooltip
                 formatter={(
                   value: number,
-                  name: 'transactionsCount' | 'stepsNumber',
+                  name: 'transactionsCountNormalized' | 'stepsNumberNormalized',
                   props,
                 ) => {
                   const valuesFormatted = {
-                    transactionsCount: formatter.format(value),
-                    stepsNumber: formatter.format(value * 100000),
+                    transactionsCountNormalized: formatter.format(
+                      props.payload.transactionsCount,
+                    ),
+                    stepsNumberNormalized: formatter.format(
+                      props.payload.stepsNumber,
+                    ),
                   }
                   const namesFormatted = {
-                    transactionsCount: 'Transactions Count',
-                    stepsNumber: 'Steps Used',
+                    transactionsCountNormalized: 'Transactions Count',
+                    stepsNumberNormalized: 'Steps Used',
                   }
                   return [valuesFormatted[name], namesFormatted[name]]
                 }}
@@ -84,14 +105,14 @@ export function TxStepsStats({
               <Line
                 type="monotone"
                 strokeWidth={2}
-                dataKey="transactionsCount"
+                dataKey="transactionsCountNormalized"
                 activeDot={{ r: 6 }}
                 stroke="#8884d8"
               />
               <Line
                 type="monotone"
                 strokeWidth={2}
-                dataKey="stepsNumber"
+                dataKey="stepsNumberNormalized"
                 activeDot={{ r: 6 }}
                 stroke="#82ca9d"
               />

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,0 +1,53 @@
+import { Redis } from '@upstash/redis'
+import { CommonStats } from './types'
+import camelcaseKeys from 'camelcase-keys'
+
+const CACHE_EXPIRATION = 3600 * 12
+
+export async function fetchCommonStats(): Promise<CommonStats> {
+  if (process.env.UPSTASH_URL && process.env.UPSTASH_TOKEN) {
+    return fetchCommonStatsWithCaching()
+  } else {
+    return fetchCommonStatsWithoutCaching()
+  }
+}
+
+async function fetchCommonStatsWithCaching(): Promise<CommonStats> {
+  const COMMON_STATS_KEY = 'common-stats'
+  const redis = new Redis({
+    url: process.env.UPSTASH_URL,
+    token: process.env.UPSTASH_TOKEN,
+  })
+
+  const ttl = await redis.ttl(COMMON_STATS_KEY)
+
+  if (ttl > 0) {
+    return (await redis.get(COMMON_STATS_KEY)) as CommonStats
+  }
+
+  const res = await fetch(
+    'http://starkf-servi-1yasdoedwfh1-321738969.us-east-1.elb.amazonaws.com/rpc/get_common_data',
+    {
+      cache: 'no-store',
+    },
+  )
+
+  const commonStats: CommonStats = camelcaseKeys((await res.json()) as any, {
+    deep: true,
+  })
+
+  await redis.setex(
+    COMMON_STATS_KEY,
+    CACHE_EXPIRATION,
+    JSON.stringify(commonStats),
+  )
+
+  return commonStats
+}
+
+async function fetchCommonStatsWithoutCaching(): Promise<CommonStats> {
+  const res = await fetch('https://starkflare.pages.dev/api/common-stats', {
+    cache: 'no-store',
+  })
+  return (await res.json()) as CommonStats
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -4,6 +4,12 @@ export interface UserStats {
   lostUsersLast7Days: number
 }
 
+export interface TransactionStats {
+  transactionsCountLast7Days: number[]
+  stepsNumberLast7Days: number[]
+}
+
 export interface CommonStats {
   userStats: UserStats
+  transactionStats: TransactionStats
 }


### PR DESCRIPTION
This PR introduces a new data tile to show transactions count and steps number using data from the starkflare-indexer.

<img width="495" alt="Screenshot 2024-05-24 at 22 17 41" src="https://github.com/walnuthq/starkflare/assets/5597359/620b2b4d-c2ee-46fa-8a4b-55cafe0ac82f">

Fixes #4