### PR TITLE
Fix: rename get_entrypoints param

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -87,12 +87,9 @@ async function fetchEntrypointsWithCaching(
 
   const provider = new RpcProvider({ nodeUrl: constants.NetworkName.SN_MAIN })
   const [res, compressedContract] = await Promise.all([
-    fetch(
-      `${RPC_URL}/get_entrypoints?contract_address_param=${contractAddress}`,
-      {
-        cache: 'no-store',
-      },
-    ),
+    fetch(`${RPC_URL}/get_entrypoints?contract_address=${contractAddress}`, {
+      cache: 'no-store',
+    }),
     provider.getClassAt(contractAddress),
   ])
 


### PR DESCRIPTION
Small fix to rename `get_entrypoints` parameter.
`contract_address_param` => `contract_address`
This should be merged after https://github.com/walnuthq/starkflare-indexer/pull/6 which is renaming the param in the backend.